### PR TITLE
[Event Hubs] Improve docs based on ux study

### DIFF
--- a/sdk/eventhub/event-hubs/src/checkpointManager.ts
+++ b/sdk/eventhub/event-hubs/src/checkpointManager.ts
@@ -6,7 +6,15 @@ import { ReceivedEventData } from "./eventData";
 import { PartitionManager } from "./eventProcessor";
 
 /**
- * A checkpoint represents the last successfully processed event by a `PartitionProcessor` for a particular partition of an Event Hub.
+ * A checkpoint is meant to represent the last successfully processed event by the user from a particular
+ * partition of a consumer group in an Event Hub instance.
+ *
+ * This is internal to how an `EventProcessor` works and the user of `EventHubClient` or `EventProcessor`
+ * never interacts with `Checkpoint` directly.
+ *
+ * When the `updateCheckpoint()` method on the `CheckpointManager` class is called by the user, a
+ * `Checkpoint` is created internally. It is then stored in the storage solution implemented by the
+ * `PartitionManager` chosen by the user when creating an `EventProcessor`.
  **/
 export interface Checkpoint {
   /**
@@ -40,8 +48,13 @@ export interface Checkpoint {
 }
 
 /**
- * The checkpoint manager is used to update checkpoints to track progress of events processed. Each
- * instance of a `PartitionProcessor` will be provided with it's own instance of a `CheckpointManager`.
+ * Users of the `EventProcessor` class use the `CheckpointManager` to update checkpoints.
+ *
+ * `EventProcessor` class instantiates this class for each partition it is processing and passes it to
+ * the user code. The user never has to instantiate this class directly.
+ *
+ * A checkpoint is meant to represent the last successfully processed event by the user from a particular
+ * partition of a consumer group in an Event Hub instance.
  */
 export class CheckpointManager {
   private _partitionContext: PartitionContext;
@@ -52,7 +65,7 @@ export class CheckpointManager {
   /**
    * @ignore
    * @internal
-   * 
+   *
    * Creates a new checkpoint manager which is passed to a `PartitionProcessor`  to update checkpoints.
    * @param partitionContext The partition context providing necessary partition and event hub information for updating
    * checkpoints.
@@ -70,19 +83,23 @@ export class CheckpointManager {
     this._eTag = "";
   }
   /**
-   * Updates the checkpoint for this partition using the event data. This will serve as the last known successfully
-   * processed event in this partition if the update is successful.
+   * Updates the checkpoint for the partition associated with the current `CheckpointManager`.
    *
-   * @param eventData The event data to use for updating the checkpoint.
+   * A checkpoint is meant to represent the last successfully processed event by the user from a particular
+   * partition of a consumer group in an Event Hub instance.
+   *
+   * @param eventData The event that you want to update the checkpoint with.
    * @return Promise<void>
    */
   public async updateCheckpoint(eventData: ReceivedEventData): Promise<void>;
   /**
-   * Updates a checkpoint using the given offset and sequence number. This will serve as the last known successfully
-   * processed event in this partition if the update is successful.
+   * Updates the checkpoint for the partition associated with the current `CheckpointManager`.
    *
-   * @param sequenceNumber The sequence number to update the checkpoint.
-   * @param offset The offset to update the checkpoint.
+   * A checkpoint is meant to represent the last successfully processed event by the user from a particular
+   * partition of a consumer group in an Event Hub instance.
+   *
+   * @param sequenceNumber The sequence number of the event that you want to update the checkpoint with.
+   * @param offset The offset of the event that you want to update the checkpoint with.
    * @return  Promise<void>.
    */
   public async updateCheckpoint(sequenceNumber: number, offset: number): Promise<void>;

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -428,11 +428,17 @@ export class EventHubClient {
    * @param consumerGroup The name of the consumer group this consumer is associated with. Events are read in the context of this group.
    * @param partitionId The identifier of the Event Hub partition from which events will be received.
    * @param eventPosition The position within the partition where the consumer should begin reading events.
+   * The easiest way to create an instance of EventPosition is to use the static helpers on it like
+   * - `EventPosition.fromOffset()`
+   * - `EventPosition.fromSequenceNumber()`
+   * - `EventPosition.fromEnqueuedTime()`
+   * - `EventPosition.earliest()`
+   * - `EventPosition.latest()`
    * @param options The set of options to apply when creating the consumer where you can specify retry options and ownerLevel.
    * - `ownerLevel`  : A number indicating that the consumer intends to be an exclusive consumer of events resulting in other
    * consumers to fail if their `ownerLevel` is lower or doesn't exist.
    * - `retryOptions`: The retry options used to govern retry attempts when an issue is encountered while receiving events.
-   * 
+   *
    * @throws {Error} Thrown if the underlying connection has been closed, create a new EventHubClient.
    * @throws {TypeError} Thrown if a required parameter is missing.
    */

--- a/sdk/eventhub/event-hubs/src/inMemoryPartitionManager.ts
+++ b/sdk/eventhub/event-hubs/src/inMemoryPartitionManager.ts
@@ -6,7 +6,14 @@ import { Checkpoint } from "./checkpointManager";
 import { generate_uuid } from "rhea-promise";
 
 /**
- * A simple in-memory implementation of a `PartitionManager`
+ * The `EventProcessor` relies on a `PartitionManager` to store checkpoints and handle partition
+ * ownerships. `InMemoryPartitionManager` is simple partition manager that stores checkpoints and
+ * partition ownerships in memory of your program.
+ * 
+ * You can use the `InMemoryPartitionManager` to get started with using the `EventProcessor`.
+ * But in production, you should choose an implementation of the `PartitionManager` interface that will
+ * store the checkpoints and partition ownerships to a durable store instead.
+ * 
  * @class
  */
 export class InMemoryPartitionManager implements PartitionManager {

--- a/sdk/eventhub/event-hubs/src/partitionContext.ts
+++ b/sdk/eventhub/event-hubs/src/partitionContext.ts
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 /**
- * PartitionContext is passed into an EventProrcessor's initialization handler and contains information
- * about the partition, the EventProcessor will be processing events from.
+ * `PartitionContext` holds information on the partition, consumer group and event hub 
+ * being processed by the `EventProcessor`.
+ * 
+ * User is never meant to create `PartitionContext` directly. It is only passed to user code
+ * by the `EventProcessor`.
  */
 export interface PartitionContext {
   /**

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -39,7 +39,7 @@ export interface EventIteratorOptions {
  * A consumer is responsible for reading `EventData` from a specific Event Hub partition
  * in the context of a specific consumer group.
  * To create a consumer use the `createConsumer()` method on your `EventHubClient`.
- * You can pass the below in the `options` when creating a producer.
+ * You can pass the below in the `options` when creating a consumer.
  * - `ownerLevel`  : A number indicating that the consumer intends to be an exclusive consumer of events resulting in other
  * consumers to fail if their `ownerLevel` is lower or doesn't exist.
  * - `retryOptions`: The retry options used to govern retry attempts when an issue is encountered while receiving events.


### PR DESCRIPTION
Based on the ux study, we found that users could very easily mistake many of the classes that are specific to Event Processor to be things that are meant to be used without the Event Processor.

This PR improves the docs to avoid this